### PR TITLE
implement restful index behind toggle

### DIFF
--- a/app/controllers/overview_controller.rb
+++ b/app/controllers/overview_controller.rb
@@ -34,8 +34,17 @@ class OverviewController < ApplicationController
   end
 
   def route_toggled_off
-    restful_routes = [ '/users' ]
-    !Flip.restful_routes? && restful_routes.include?(request.path)
+    new_route_off || old_route_off
+  end
+
+  def new_route_off
+    new_routes = [ '/users' ]
+    !Flip.restful_routes? && new_routes.include?(request.path)
+  end
+
+  def old_route_off
+    old_routes = [ '/overview/index' ]
+    Flip.restful_routes? && old_routes.include?(request.path)
   end
 
   def raise_404

--- a/app/controllers/overview_controller.rb
+++ b/app/controllers/overview_controller.rb
@@ -1,7 +1,12 @@
 class OverviewController < ApplicationController
   def index
-    @users = User.all || []
-    @chucknorris = JSON.parse(HTTParty.get('https://api.chucknorris.io/jokes/random').body)
+    raise_404 unless Flip.restful_routes?
+    index_actions
+  end
+
+  def old_index
+    index_actions
+    render 'index'
   end
 
   def create_user
@@ -30,5 +35,14 @@ class OverviewController < ApplicationController
 
   def user_params
     params.require(:user).permit(:id, :first_name, :middle_name, :last_name, :role)
+  end
+
+  def index_actions
+    @users = User.all || []
+    @chucknorris = JSON.parse(HTTParty.get('https://api.chucknorris.io/jokes/random').body)
+  end
+
+  def raise_404
+    raise ActionController::RoutingError.new('Not Found')
   end
 end

--- a/app/controllers/overview_controller.rb
+++ b/app/controllers/overview_controller.rb
@@ -1,12 +1,8 @@
 class OverviewController < ApplicationController
   def index
-    raise_404 unless Flip.restful_routes?
-    index_actions
-  end
-
-  def old_index
-    index_actions
-    render 'index'
+    raise_404 if route_toggled_off
+    @users = User.all || []
+    @chucknorris = JSON.parse(HTTParty.get('https://api.chucknorris.io/jokes/random').body)
   end
 
   def create_user
@@ -37,9 +33,9 @@ class OverviewController < ApplicationController
     params.require(:user).permit(:id, :first_name, :middle_name, :last_name, :role)
   end
 
-  def index_actions
-    @users = User.all || []
-    @chucknorris = JSON.parse(HTTParty.get('https://api.chucknorris.io/jokes/random').body)
+  def route_toggled_off
+    restful_routes = [ '/users' ]
+    !Flip.restful_routes? && restful_routes.include?(request.path)
   end
 
   def raise_404

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -8,4 +8,8 @@ class Feature < ActiveRecord::Base
 
   feature :placeholder_over_label,
           description: 'When this toggle is turned on, there will no longer be labels.'
+
+  feature :restful_routes,
+        default: true,
+        description: 'When this toggle is turned on, the profile route will follow RESTful conventions.'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
-  root 'overview#index'
-  get 'overview/index'
+  root 'overview#old_index'
+  get 'overview/index', to: 'overview#old_index'
+  get 'users', to: 'overview#index'
   get 'who_am_i', to: 'overview#who_am_i'
   get 'edit_user', to: 'overview#edit_user'
   post 'create_user', to: 'overview#create_user'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
-  root 'overview#old_index'
-  get 'overview/index', to: 'overview#old_index'
+  root 'overview#index'
+  get 'overview/index', to: 'overview#index'
   get 'users', to: 'overview#index'
   get 'who_am_i', to: 'overview#who_am_i'
   get 'edit_user', to: 'overview#edit_user'


### PR DESCRIPTION
Currently functionality:
* throw 404 for old index route when toggle is on
* throw 404 for new index route when toggle is off

As this refactor grows:
* 'raise_404 if route_toggled_off' becomes a before action
* paths are added to new_route_off and old_route_off methods
